### PR TITLE
backwards diffs for JopGradient on edges

### DIFF
--- a/src/jop_gradient.jl
+++ b/src/jop_gradient.jl
@@ -44,13 +44,23 @@ export JopGradient
 function JopGradient_df!(d::AbstractArray{T,3}, m::AbstractArray{T,2}; δ, kwargs...) where {T}
     d .= 0
     n1,n2 = size(m)
-    for k1=1:n1-1, k2=1:n2
-        d[k1,k2,1] += m[k1+1,k2] / δ[1]
-        d[k1,k2,1] -= m[k1+0,k2] / δ[1]
+    for k1=1:n1, k2=1:n2
+        if k1 < n1
+            d[k1,k2,1] += m[k1+1,k2] / δ[1]
+            d[k1,k2,1] -= m[k1+0,k2] / δ[1]
+        else
+            d[k1,k2,1] += m[k1+0,k2] / δ[1]
+            d[k1,k2,1] -= m[k1-1,k2] / δ[1]
+        end
     end
-    for k1=1:n1, k2=1:n2-1
-        d[k1,k2,2] += m[k1,k2+1] / δ[2]
-        d[k1,k2,2] -= m[k1,k2+0] / δ[2]
+    for k1=1:n1, k2=1:n2
+        if k2 < n2
+            d[k1,k2,2] += m[k1,k2+1] / δ[2]
+            d[k1,k2,2] -= m[k1,k2+0] / δ[2]
+        else
+            d[k1,k2,2] += m[k1,k2+0] / δ[2]
+            d[k1,k2,2] -= m[k1,k2-1] / δ[2]
+        end
     end
     d
 end
@@ -58,13 +68,23 @@ end
 function JopGradient_df′!(m::AbstractArray{T,2}, d::AbstractArray{T,3}; δ, kwargs...) where {T}
     m .= 0
     n1,n2 = size(m)
-    for k1=1:n1-1, k2=1:n2
-        m[k1+1,k2] += d[k1,k2,1] / δ[1]
-        m[k1+0,k2] -= d[k1,k2,1] / δ[1]
+    for k1=1:n1, k2=1:n2
+        if k1 < n1
+            m[k1+1,k2] += d[k1,k2,1] / δ[1]
+            m[k1+0,k2] -= d[k1,k2,1] / δ[1]
+        else
+            m[k1+0,k2] += d[k1,k2,1] / δ[1]
+            m[k1-1,k2] -= d[k1,k2,1] / δ[1]
+        end
     end
-    for k1=1:n1, k2=1:n2-1
-        m[k1,k2+1] += d[k1,k2,2] / δ[2]
-        m[k1,k2+0] -= d[k1,k2,2] / δ[2]
+    for k1=1:n1, k2=1:n2
+        if k2 < n2
+            m[k1,k2+1] += d[k1,k2,2] / δ[2]
+            m[k1,k2+0] -= d[k1,k2,2] / δ[2]
+        else
+            m[k1,k2+0] += d[k1,k2,2] / δ[2]
+            m[k1,k2-1] -= d[k1,k2,2] / δ[2]
+        end
     end
     m
 end
@@ -75,17 +95,32 @@ end
 function JopGradient_df!(d::AbstractArray{T,4}, m::AbstractArray{T,3}; δ, kwargs...) where {T}
     d .= 0
     n1,n2,n3 = size(d)
-    for k1=1:n1-1, k2=1:n2, k3=1:n3
-        d[k1,k2,k3,1] += m[k1+1,k2,k3] / δ[1]
-        d[k1,k2,k3,1] -= m[k1+0,k2,k3] / δ[1]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k1 < n1
+            d[k1,k2,k3,1] += m[k1+1,k2,k3] / δ[1]
+            d[k1,k2,k3,1] -= m[k1+0,k2,k3] / δ[1]
+        else
+            d[k1,k2,k3,1] += m[k1+0,k2,k3] / δ[1]
+            d[k1,k2,k3,1] -= m[k1-1,k2,k3] / δ[1]
+        end
     end
-    for k1=1:n1, k2=1:n2-1, k3=1:n3
-        d[k1,k2,k3,2] += m[k1,k2+1,k3] / δ[2]
-        d[k1,k2,k3,2] -= m[k1,k2+0,k3] / δ[2]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k2 < n2
+            d[k1,k2,k3,2] += m[k1,k2+1,k3] / δ[2]
+            d[k1,k2,k3,2] -= m[k1,k2+0,k3] / δ[2]
+        else
+            d[k1,k2,k3,2] += m[k1,k2+0,k3] / δ[2]
+            d[k1,k2,k3,2] -= m[k1,k2-1,k3] / δ[2]
+        end
     end
-    for k1=1:n1, k2=1:n2, k3=1:n3-1
-        d[k1,k2,k3,3] += m[k1,k2,k3+1] / δ[3]
-        d[k1,k2,k3,3] -= m[k1,k2,k3+0] / δ[3]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k3 < n3
+            d[k1,k2,k3,3] += m[k1,k2,k3+1] / δ[3]
+            d[k1,k2,k3,3] -= m[k1,k2,k3+0] / δ[3]
+        else
+            d[k1,k2,k3,3] += m[k1,k2,k3+0] / δ[3]
+            d[k1,k2,k3,3] -= m[k1,k2,k3-1] / δ[3]
+        end
     end
     d
 end
@@ -93,17 +128,32 @@ end
 function JopGradient_df′!(m::AbstractArray{T,3}, d::AbstractArray{T,4}; δ, kwargs...) where {T}
     m .= 0
     n1,n2,n3 = size(m)
-    for k1=1:n1-1, k2=1:n2, k3=1:n3
-        m[k1+1,k2,k3] += d[k1,k2,k3,1] / δ[1]
-        m[k1+0,k2,k3] -= d[k1,k2,k3,1] / δ[1]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k1 < n1
+            m[k1+1,k2,k3] += d[k1,k2,k3,1] / δ[1]
+            m[k1+0,k2,k3] -= d[k1,k2,k3,1] / δ[1]
+        else
+            m[k1+0,k2,k3] += d[k1,k2,k3,1] / δ[1]
+            m[k1-1,k2,k3] -= d[k1,k2,k3,1] / δ[1]
+        end
     end
-    for k1=1:n1, k2=1:n2-1, k3=1:n3
-        m[k1,k2+1,k3] += d[k1,k2,k3,2] / δ[2]
-        m[k1,k2+0,k3] -= d[k1,k2,k3,2] / δ[2]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k2 < n2
+            m[k1,k2+1,k3] += d[k1,k2,k3,2] / δ[2]
+            m[k1,k2+0,k3] -= d[k1,k2,k3,2] / δ[2]
+        else
+            m[k1,k2+0,k3] += d[k1,k2,k3,2] / δ[2]
+            m[k1,k2-1,k3] -= d[k1,k2,k3,2] / δ[2]
+        end
     end
-    for k1=1:n1, k2=1:n2, k3=1:n3-1
-        m[k1,k2,k3+1] += d[k1,k2,k3,3] / δ[3]
-        m[k1,k2,k3+0] -= d[k1,k2,k3,3] / δ[3]
+    for k1=1:n1, k2=1:n2, k3=1:n3
+        if k3 < n3
+            m[k1,k2,k3+1] += d[k1,k2,k3,3] / δ[3]
+            m[k1,k2,k3+0] -= d[k1,k2,k3,3] / δ[3]
+        else
+            m[k1,k2,k3+0] += d[k1,k2,k3,3] / δ[3]
+            m[k1,k2,k3-1] -= d[k1,k2,k3,3] / δ[3]
+        end
     end
     m
 end


### PR DESCRIPTION
adds backwards one sided diffs on the edges where previously no derivatives were computed. 