### PR TITLE
Enable multithreading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JetPack"
 uuid = "24ef3835-3876-54c3-8a7a-956cf69ca0b2"
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/jop_CubicSpline.jl
+++ b/src/jop_CubicSpline.jl
@@ -218,7 +218,7 @@ function JopCubicSpline_df!(d::AbstractArray{T,3}, m::AbstractArray{T,3}; kernel
     nc2 = size(m,2)
     nc3 = size(m,3)
     for ic3 = 1:nc3
-        for k = iminmax3[ic3,1]:iminmax3[ic3,2]
+        Threads.@threads :static for k = iminmax3[ic3,1]:iminmax3[ic3,2]
             for ic2 = 1:nc2
                 for j = iminmax2[ic2,1]:iminmax2[ic2,2]
                     for ic1 = 1:nc1
@@ -238,7 +238,7 @@ function JopCubicSpline_df′!(m::AbstractArray{T,3}, d::AbstractArray{T,3}; ker
     nc1 = size(m,1)
     nc2 = size(m,2)
     nc3 = size(m,3)
-    for ic3 = 1:nc3
+    Threads.@threads :static for ic3 = 1:nc3
         for k = iminmax3[ic3,1]:iminmax3[ic3,2]
             for ic2 = 1:nc2
                 for j = iminmax2[ic2,1]:iminmax2[ic2,2]
@@ -262,7 +262,7 @@ function JopCubicSpline_df!(d::AbstractArray{T,4}, m::AbstractArray{T,4}; kernel
     nc = size(m,4)
     for c = 1:nc
         for ic3 = 1:nc3
-            for k = iminmax3[ic3,1]:iminmax3[ic3,2]
+            Threads.@threads :static for k = iminmax3[ic3,1]:iminmax3[ic3,2]
                 for ic2 = 1:nc2
                     for j = iminmax2[ic2,1]:iminmax2[ic2,2]
                         for ic1 = 1:nc1
@@ -285,7 +285,7 @@ function JopCubicSpline_df′!(m::AbstractArray{T,4}, d::AbstractArray{T,4}; ker
     nc3 = size(m,3)
     nc = size(m,4)
     for c = 1:nc
-        for ic3 = 1:nc3
+        Threads.@threads :static for ic3 = 1:nc3
             for k = iminmax3[ic3,1]:iminmax3[ic3,2]
                 for ic2 = 1:nc2
                     for j = iminmax2[ic2,1]:iminmax2[ic2,2]

--- a/test/jop_CubicSpline.jl
+++ b/test/jop_CubicSpline.jl
@@ -1,7 +1,3 @@
-import Pkg
-if !any(dep.name == "IterativeSolvers" for dep in values(Pkg.dependencies()))
-    Pkg.add("IterativeSolvers")
-end
 using Jets, LinearAlgebra, IterativeSolvers, Test, JetPack
 
 PLOTS = parse(Int32, get(ENV, "JP_PLOTS", "0"))

--- a/test/jop_CubicSpline.jl
+++ b/test/jop_CubicSpline.jl
@@ -1,3 +1,7 @@
+import Pkg
+if !any(dep.name == "IterativeSolvers" for dep in values(Pkg.dependencies()))
+    Pkg.add("IterativeSolvers")
+end
 using Jets, LinearAlgebra, IterativeSolvers, Test, JetPack
 
 PLOTS = parse(Int32, get(ENV, "JP_PLOTS", "0"))


### PR DESCRIPTION
Enable multithreading using `Base.Threads` in the 3D Bspline Jet operator `jop_CubicSpline` to improve performance.