### PR TITLE
fix bug in JopNormalize linearization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JetPack"
 uuid = "24ef3835-3876-54c3-8a7a-956cf69ca0b2"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/jop_normalize.jl
+++ b/src/jop_normalize.jl
@@ -46,7 +46,12 @@ function JopNormalize_df!(δd::AbstractArray{T}, δm::AbstractArray{T}; mₒ, ϵ
         for k2 ∈ 1:n2
             (mode === :trace) && (_corr = dot(_mₒ[:,k2,k3], _δm[:,k2,k3]))
             (mode === :trace) && (_norm = dot(_mₒ[:,k2,k3], _mₒ[:,k2,k3]))
-            _δd[:,k2,k3] .= _δm[:,k2,k3] ./ (sqrt(_norm) + ϵ) .- _mₒ[:,k2,k3] .* _corr ./ ((sqrt(_norm) + ϵ)^2 * sqrt(_norm + ϵ))
+            _nrm = sqrt(_norm)
+            if _nrm > 0
+                _δd[:,k2,k3] .= _δm[:,k2,k3] ./ (_nrm + ϵ) .- _mₒ[:,k2,k3] .* _corr ./ ((_nrm + ϵ)^2 * _nrm)
+            else
+                _δd[:,k2,k3] .= _δm[:,k2,k3] ./ ϵ
+            end
         end
     end
     δd

--- a/test/jop_normalize.jl
+++ b/test/jop_normalize.jl
@@ -20,7 +20,7 @@ n1,n2 = 20,5
 end
 
 @testset "JopNormalize, linearity test, T=$(T), n3=$n3, mode=$mode" for T in (Float32, Float64), n3 in (1,7), mode in (:trace,:shot)
-    ϵ = T(1.e-8)
+    ϵ = T(1.e-3)
     F = JopNormalize(JetSpace(T,n1,n2,n3);ϵ,mode)
     J = jacobian(F, rand(domain(F)))
     lhs,rhs = linearity_test(J)
@@ -30,14 +30,15 @@ end
 end
 
 @testset "JopNormalize, dot product test, T=$(T), n3=$n3, mode=$mode" for T in (Float32, Float64), n3 in (1,7), mode in (:trace,:shot)
-    F = JopNormalize(JetSpace(T,n1,n2,n3))
+    ϵ = T(1.e-3)
+    F = JopNormalize(JetSpace(T,n1,n2,n3); ϵ=ϵ, mode=mode)
     J  = jacobian!(F, rand(domain(F)))
     lhs, rhs = dot_product_test(J, -1 .+ 2 .* rand(domain(J)), -1 .+ 2 .* rand(range(J)))
     @test lhs ≈ rhs
 end
 
-@testset "JopNormalize, linearization test, T=$(T), n3=$n3, mode=$mode" for T in (Float32, Float64), n3 in (1,7), mode in (:trace,:shot)
-    F = JopNormalize(JetSpace(T,n1,n2,n3))
+@testset "JopNormalize, linearization test, T=$(T), n3=$n3, mode=$mode, ϵ=$(ϵ)" for T in (Float32, Float64), n3 in (1,7), mode in (:trace,:shot), ϵ in (1e-8, 1e-1)
+    F = JopNormalize(JetSpace(T,n1,n2,n3); ϵ=T(ϵ), mode=mode)
     m0 = rand(domain(F))
     δm = T(0.1) .* rand(domain(F))
     μ = ones(T, 10) 


### PR DESCRIPTION
The linearization of the JopNormalize operator was incorrect, I fixed it.

PS: I spotted the bug while testing the adjoint source correctness for my rigorous FWI! Thank you mathematics :-)